### PR TITLE
Added recently created testnet nodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1203,8 +1203,8 @@ static const char *strMainNetDNSSeed[][14] = {
 };
 
 static const char *strTestNetDNSSeed[][14] = {
-    {NULL, NULL},
-    {NULL, NULL},
+	{"devcoin.cloud", "node1.devcoin.cloud"},
+	{"devcoinresource.com", "phoenix.devcoinresource.com"},
 	{NULL, NULL},
 	{NULL, NULL},
 	{NULL, NULL},

--- a/src/receiver.h
+++ b/src/receiver.h
@@ -594,7 +594,8 @@ string getStepText(const string& dataDirectory, const string& fileName, int heig
 		{
 			cout << "Downloading " << stepFileName << " base file." << directorySubName << endl;
 			string peerText = string("_beginpeers\n");
-			peerText += string("https://raw.github.com/sidhujag/devcoin/master/src/node2/testnet3/receiverTestNet/receiverTestNet.csv\n");
+			peerText += string("http://node1.devcoin.cloud/testnet_receiver_files/receiverTestNet.csv\n");
+			peerText += string("http://devcoinresource.com/testnet_receiver_files/receiverTestNet.csv\n");
 			peerText += string("_endpeers\n");
 			stepText = getCommonOutputByText(peerText, string("0"));
 			if (getStartsWith(stepText, string("Format,pluribusunum")))


### PR DESCRIPTION
I removed the old testnet receiver node since it was pointing to https://githib which does not work because we don't support https receiver locations yet.

I added two new testnet node locations which I will maintain for the testnet SEED addresses

I also added testnet receiver files and tested with a new build to be sure it is downloaded.

It worked, so we have a live testnet with receiver files now, which is great for our upcoming code changes and Quality Checks
