### PR TITLE
Replacing unavaiable seed node with CTYA node node1.devcoin.cloud

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1188,7 +1188,7 @@ void MapPort(bool)
 // The second name should resolve to a list of seed addresses.
 static const char *strMainNetDNSSeed[][14] = {
 	{"public.txn.co.in", "dvc.public.txn.co.in"},
-	{"21stcenturymoneytalk.org", "dvc-seed.21stcenturymoneytalk.org"},
+        {"devcoin.cloud", "node1.devcoin.cloud"},
 	{"dvcnode.org", "dvcstable01.dvcnode.org"},
 	{"dvcnode.org", "dvcstable02.dvcnode.org"},
 	{"dvcnode.org", "dvcstable03.dvcnode.org"},

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1188,7 +1188,7 @@ void MapPort(bool)
 // The second name should resolve to a list of seed addresses.
 static const char *strMainNetDNSSeed[][14] = {
 	{"public.txn.co.in", "dvc.public.txn.co.in"},
-        {"devcoin.cloud", "node1.devcoin.cloud"},
+	{"devcoin.cloud", "node1.devcoin.cloud"},
 	{"dvcnode.org", "dvcstable01.dvcnode.org"},
 	{"dvcnode.org", "dvcstable02.dvcnode.org"},
 	{"dvcnode.org", "dvcstable03.dvcnode.org"},


### PR DESCRIPTION
21stcenturymoneytalk.org is not a hosted seed node anymore

My node at node1.devcoin.cloud is a full node, serving receivers and hosting a block explorer.

It will serve well as a stable seed node to replace the abandoned node.

