### PR TITLE
Add node1.devcoin.cloud to receiver seed node list

### DIFF
--- a/src/receiver.h
+++ b/src/receiver.h
@@ -584,6 +584,7 @@ string getStepText(const string& dataDirectory, const string& fileName, int heig
 			peerText += string("http://galaxies.mygamesonline.org/receiver.csv\n");
 			peerText += string("http://devcoinpool.btc-music.com/receiver/receiver.csv\n");
 			peerText += string("http://devcoin.darkgamex.ch/receiver.csv\n");
+			peerText += string("http://node1.devcoin.cloud/receiver_files/receiver.csv\n");
 			peerText += string("_endpeers\n");
 			stepText = getCommonOutputByText(peerText, string("0"));
 			if (getStartsWith(stepText, string("Format,pluribusunum")))


### PR DESCRIPTION
node1.devcoin.cloud is a receiver host and included in every receiver file already.  Adding it to the list of seed receivers as well to improve connection and start up time.

