### PR TITLE
corrected missing separators and bad syntax in OSX makefile

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -35,7 +35,7 @@ ifdef STATIC
 TESTLIBS += \
  $(DEPSDIR)/lib/libboost_unit_test_framework-mt.a
 LIBS += \
- -l leveldb \
+ -lleveldb \
  $(DEPSDIR)/lib/db48/libdb_cxx-4.8.a \
  $(DEPSDIR)/lib/libboost_system-mt.a \
  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
@@ -44,13 +44,13 @@ LIBS += \
  $(DEPSDIR)/lib/libboost_chrono-mt.a \
  $(DEPSDIR)/lib/libssl.a \
  $(DEPSDIR)/lib/libcrypto.a \
- -lz
- -l curl
+ -lz \
+ -lcurl
 else
 TESTLIBS += \
  -lboost_unit_test_framework-mt
 LIBS += \
- -l leveldb \	
+ -l leveldb \
  -ldb_cxx-4.8 \
  -lboost_system-mt \
  -lboost_filesystem-mt \
@@ -59,8 +59,8 @@ LIBS += \
  -lboost_chrono-mt \
  -lssl \
  -lcrypto \
- -lz
- -l curl
+ -lz \
+ -lcurl
 TESTDEFS += -DBOOST_TEST_DYN_LINK
 endif
 
@@ -144,7 +144,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 
 curl/lib/.libs/libcurl.a:
 	@echo "Building LibCurl ..."
-	cd curl; ./buildconf; ./configure --disable-shared --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smtp  --disable-gopher --disable-manual --disable-imap --disable-zlib --without-ca-bundle --without-gnutls --without-libidn --without-librtmp --without-libssh2 --without-nss --without-ssl --without-zlib; $(MAKE); cd ..
+	cd curl; ./buildconf; ./configure --disable-shared --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smtp  --disable-gopher --disable-manual --disable-imap --disable-zlib --without-ca-bundle --without-gnutls --without-libidn --without-librtmp --without-libssh2 --without-nss --without-zlib; $(MAKE); cd ..
 	
 leveldb/libleveldb.a:
 	@echo "Building LevelDB ..."


### PR DESCRIPTION
These extra spaces and missing separators prevent the OSX make from building devcoind
