### PR TITLE
rewrite Dockerfile following the guide of best practices from docker upstream - Bounty: 500K DVC

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -42,15 +42,17 @@ FROM osixia/light-baseimage:1.1.2
 
 COPY --from=builder /usr/local/bin/devcoind /usr/local/bin/devcoind
 # Update packages and install package dependencies
-RUN apt-get update && apt-get install -y \
-        libboost-system1.62.0 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-thread1.62.0 \
-    && rm -rf /var/lib/apt/lists/*;
+RUN apt-get -y update \
+    && /container/tool/add-multiple-process-stack \
+    && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       libboost-system1.62.0 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-thread1.62.0 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Create devcoin user
-RUN useradd devcoin; chsh -s /bin/bash devcoin
-RUN mkdir -p /home/devcoin/.devcoin
+RUN useradd devcoin; chsh -s /bin/bash devcoin; mkdir -p /home/devcoin/.devcoin
 
-# Setup devcoind
+# Configure devcoind settings
 RUN echo '#Noob config file for devcoind, should be enough!\n\
 server=1\n\
 daemon=0\n\
@@ -72,11 +74,19 @@ txindex=1\n\
 > /home/devcoin/.devcoin/devcoin.conf
 RUN chown devcoin: -R /home/devcoin
 
-# Configure service
-RUN mkdir -p /container/service/devcoind
-RUN echo '#!/bin/bash -e\n\
-exec /bin/su devcoin -c "/usr/local/bin/devcoind"\n'\
-> /container/service/devcoind/process.sh
-RUN chmod +x /container/service/devcoind/process.sh
+# Setup devcoind service
+ENV DEVCOIND /container/run/process/devcoind
+RUN mkdir /var/log/devcoind; mkdir -p $DEVCOIND/log; echo '#!/bin/sh\n\
+\n\
+exec 2>&1\n\
+\n\
+cd /home/devcoin/; exec /sbin/setuser devcoin devcoind\n\
+'\
+> $DEVCOIND/run
+RUN echo '#!/bin/sh\n\
+exec /usr/bin/svlogd -tt /var/log/devcoind\n\
+'\
+> $DEVCOIND/log/run
+RUN chmod +x $DEVCOIND/run; chmod +x $DEVCOIND/log/run; ln -s $DEVCOIND /etc/service/
 
 EXPOSE 52332

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,23 +1,50 @@
 #
 # Dockerfile for Devcoind
 #
-# version: 0.1.1
+# version: 0.2.0
 #
 
-FROM phusion/baseimage:0.11
+FROM debian:stretch-slim as builder
 MAINTAINER Fernando Paredes Garcia <fernando@develcuy.com>
 
-# Update packages
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
-
-# Install package dependencies
-#RUN apt-get install -y --force-yes libdb4.8-dev libdb4.8++-dev build-essential libboost-all-dev git supervisor
-#RUN apt-get install -y procps
-
-RUN apt-get install -y --force-yes git libdb++-dev libdb-dev libboost-all-dev build-essential libtool pkg-config libssl-dev
+# Update packages and install package dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ca-certificates libboost-all-dev libssl-dev libz-dev git wget \
+    && rm -rf /var/lib/apt/lists/*;
+ENV SRC /usr/local/src
+ENV BDBVER db-4.8.30.NC
+WORKDIR $SRC
+# Download and Compile Berkeley DB 4.8
+RUN set -ex; \
+        mkdir -p $SRC/db4_dest; \
+        wget --quiet https://download.oracle.com/berkeley-db/$BDBVER.tar.gz; \
+        echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  $BDBVER.tar.gz" | sha256sum -c - || exit 1; \
+        tar -xzf $BDBVER.tar.gz; \
+        cd $BDBVER/build_unix/; \
+        sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ../dbinc/atomic.h; \
+        ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$SRC/db4_dest; \
+        make install; \
+        cd $SRC; \
+        rm -rf $BDBVER $BDBVER.tar.gz db4_dest/docs
 
 # Download Devcoind source
-RUN git clone --depth=1 https://github.com/devcoin/core.git /usr/local/src/devcoin
+RUN git clone --depth=1 https://github.com/devcoin/core.git $SRC/devcoin
+# Compile & Install Devcoind
+RUN set -ex; \
+        cd $SRC/devcoin/src; \
+        make -j4 -f makefile.unix USE_UPNP=- BDB_LIB_PATH=$SRC/db4_dest/lib/ BDB_INCLUDE_PATH=$SRC/db4_dest/include/; \
+        strip devcoind; \
+        mv devcoind /usr/local/bin/; \
+        make -f makefile.unix clean
+
+# Use osixia/light-baseimage
+# https://github.com/osixia/docker-light-baseimage
+FROM osixia/light-baseimage:1.1.2
+
+COPY --from=builder /usr/local/bin/devcoind /usr/local/bin/devcoind
+# Update packages and install package dependencies
+RUN apt-get update && apt-get install -y \
+        libboost-system1.62.0 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-thread1.62.0 \
+    && rm -rf /var/lib/apt/lists/*;
 
 # Create devcoin user
 RUN useradd devcoin; chsh -s /bin/bash devcoin
@@ -45,37 +72,11 @@ txindex=1\n\
 > /home/devcoin/.devcoin/devcoin.conf
 RUN chown devcoin: -R /home/devcoin
 
-# Setup devcoind service
-RUN useradd logger; chsh -s /bin/bash logger; mkdir /var/log/devcoind;
-RUN mkdir -p /etc/sv/devcoind/log
-RUN echo '#!/bin/sh\n\
-\n\
-exec 2>&1\n\
-\n\
-cd /home/devcoin/; exec /sbin/setuser devcoin devcoind\n\
-'\
-> /etc/sv/devcoind/run
-RUN echo '#!/bin/sh\n\
-exec /usr/bin/svlogd -tt /var/log/devcoind\n\
-'\
-> /etc/sv/devcoind/log/run
-RUN chmod +x /etc/sv/devcoind/run; chmod +x /etc/sv/devcoind/log/run; ln -s /etc/sv/devcoind /etc/service/
-
-# Compile & Install Devcoind
-RUN echo 'cd /usr/local/src/devcoin/src/\n\
-make -f makefile.unix clean\n\
-make -f makefile.unix USE_UPNP=- devcoind\n\
-'\
-> /root/compile-devcoin.sh
-RUN /bin/bash /root/compile-devcoin.sh
-RUN mv /usr/local/src/devcoin/src/devcoind /usr/local/bin/
+# Configure service
+RUN mkdir -p /container/service/devcoind
+RUN echo '#!/bin/bash -e\n\
+exec /bin/su devcoin -c "/usr/local/bin/devcoind"\n'\
+> /container/service/devcoind/process.sh
+RUN chmod +x /container/service/devcoind/process.sh
 
 EXPOSE 52332
-
-# Use baseimage-docker's init process.
-CMD ["/sbin/my_init"]
-
-# Clean up APT when done.
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-WORKDIR /home/devcoin


### PR DESCRIPTION
1. 'set -ex' instead of separated RUN or write bash script file in place;
2. Build db4.8 from source instead of messing with old debian sources.list;
3. using multi-stage builds to greatly decrease the resulting image(from more than 1.2G to 130M).